### PR TITLE
Widen "repo directory" column

### DIFF
--- a/github/watchdog
+++ b/github/watchdog
@@ -15,12 +15,12 @@ subject="GitHub AFS backups watchdog"
 
 pretty_mtime() {
     # Pretty-print the mtime of a file
-    date --date=@`stat --format %Y "$1"`
+    date +'%a %x %X' --date=@`stat --format %Y "$1"`
 }
 
 cd $repodir
 
-fmtstr='%-30s %-32s %s\n'
+fmtstr='%-35s %-22s %s\n'
 
 # Build the body of the email
 {

--- a/github/watchdog
+++ b/github/watchdog
@@ -15,7 +15,7 @@ subject="GitHub AFS backups watchdog"
 
 pretty_mtime() {
     # Pretty-print the mtime of a file
-    date +'%a %x %X' --date=@`stat --format %Y "$1"`
+    date +'%a %x %X' -r "$1"
 }
 
 cd $repodir


### PR DESCRIPTION
Tweak the output of the GitHub AFS backups watchdog script to widen the "repo directory" column.
The date format was changed so the "last successful fetch" column could be narrowed.