### PR TITLE
Use new koji-hub hostname for URLs koji-build-table generates (SOFTWARE-2175)

### DIFF
--- a/koji-build-table
+++ b/koji-build-table
@@ -11,7 +11,7 @@ import sys
 
 from optparse import OptionParser
 
-KOJI_WEB = "https://koji-hub.batlab.org"
+KOJI_WEB = "https://koji.chtc.wisc.edu"
 
 def get_args(argv):
     usage = """\


### PR DESCRIPTION
koji-hub.batlab.org is getting renamed to koji.chtc.wisc.edu and any URLs generated by scripts should use the new hostname.