### PR TITLE
script for listing rpm versions from osg test runs

### DIFF
--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -88,10 +88,13 @@ def dist_strip(evr):
     r = re.sub(dist_pat, '', r)
     return '-'.join([ev,r])
 
+def group_adjacent(a,k):
+    ''' group_adjacent([1,2,3,4,5,6], 3) -> [(1,2,3), (4,5,6)] '''
+    return zip(*([iter(a)] * k))
+
 def nvrgen(items):
     # generate sequence of ["name.arch", "epoch:version-release"] pairs
-    while items:
-        na, evr = items[:2]
+    for na,evr in group_adjacent(items, 2):
         if strip_arch:
             na = arch_strip(na)
         if strip_dist:
@@ -99,7 +102,6 @@ def nvrgen(items):
         if evr.startswith("0:"):
             evr = evr[2:]
         yield [na,evr]
-        items[:2] = []
 
 def rpm_qa2na_vr(line):
     line = re.sub(r'(\.rpm)?\r?\n?$', '', line)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -232,6 +232,7 @@ def summarize_outputs(rundir, pkgs):
             pkgstats[pkg][vr] += [outputnum(output)]
 
     header = get_summary_header()
+    separator = [''] * len(header)
     pkgstatslist = []
     for pkg in sorted(pkgstats):
         for vr in sorted(pkgstats[pkg], cmp=rpmvercmp):
@@ -242,7 +243,7 @@ def summarize_outputs(rundir, pkgs):
                     nums_str += ",..."
                 row.append(nums_str)
             pkgstatslist.append(row)
-        pkgstatslist.append([''] * len(header))
+        pkgstatslist.append(separator)
 
     print_table(header, pkgstatslist)
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -236,10 +236,11 @@ def summarize_outputs(rundir, pkgs):
     pkgstatslist = []
     for pkg in sorted(pkgstats):
         for vr in sorted(pkgstats[pkg], cmp=rpmvercmp):
-            row = [pkg, vr, str(len(pkgstats[pkg][vr]))]
+            count = len(pkgstats[pkg][vr])
+            row = [pkg, vr, str(count)]
             if list_nums:
                 nums_str =','.join(pkgstats[pkg][vr][:max_nums])
-                if len(pkgstats[pkg][vr]) > max_nums:
+                if count > max_nums:
                     nums_str += ",..."
                 row.append(nums_str)
             pkgstatslist.append(row)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -27,7 +27,9 @@ Options:
 """
 
 import collections
+import itertools
 import getopt
+import pickle
 import glob
 import stat
 import sys
@@ -224,13 +226,27 @@ def get_run_output_dirs(rundir):
 
     return outputs
 
+# run a function call in a background coprocess, return callable result
+def bgcall(func, *a, **kw):
+    r,w = itertools.starmap(os.fdopen, zip(os.pipe(), "rw"))
+
+    if os.fork():  # parent
+        w.close()
+        return lambda : pickle.load(r)
+    else:  # child
+        r.close()
+        ret = func(*a,**kw)
+        s = pickle.dump(ret, w)
+        w.close()
+        os._exit(0)
+
 def summarize_outputs(rundir, pkgs):
     outputs = get_run_output_dirs(rundir)
 
     pkgstats = autodict()
-    for output in outputs:
-        pkg_vrs = single_output_pkg_vrs(output, pkgs)
-        for pkg,vr in pkg_vrs:
+    bgcalls = [ bgcall(single_output_pkg_vrs, o, pkgs) for o in outputs ]
+    for get_pkg_vrs,output in zip(bgcalls, outputs):
+        for pkg,vr in get_pkg_vrs():
             pkgstats[pkg][vr] += [outputnum(output)]
 
     header = get_summary_header()

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -2,7 +2,8 @@
 
 """
 Usage:
-  %s [options] output-001 [packages...]
+  %(script)s [options] output-001 [packages...]
+  %(script)s [options] --summarize [run-]20161220-1618 packages...
 
 List version-release numbers for RPMs installed in an osg-test run output
 directory, as found in output-NNN/output/osg-test-*.log
@@ -12,9 +13,14 @@ or the raw output of an 'rpm -qa' command.
 
 If any packages are specified, limit the results to just those packages.
 
+If a run directory (or, just the timstamp string) is specified, summary
+information will be printed for the listed packages across all output-NNN
+subdirectories for that set of osg test runs.
+
 Options:
   -A, --no-strip-arch  don't attempt to strip .arch from package names
   -D, --no-strip-dist  don't attempt to strip .dist tag from package releases
+  -s, --summarize      summarize results for all output subdirs
 """
 
 import collections
@@ -40,7 +46,7 @@ def usage(msg=None):
     if msg:
         print msg
         print
-    print __doc__ % os.path.basename(__file__)
+    print __doc__ % {"script": os.path.basename(__file__)}
     sys.exit()
 
 def parseargs():

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -152,29 +152,29 @@ def print_table(header, table):
         spacing = [ w-len(x) for x,w in zip(row,widths) ]
         print '  '.join( r + ' ' * s for r,s in zip(row,spacing) ).rstrip()
 
-def single_output_pkg_vrs(output, pkgs):
-    rpms = nvrmap(output)
+def single_output_pkg_vrs(output, want_pkgs):
+    have_rpms = nvrmap(output)
 
     # arch-stripped rpm names
     if strip_arch:
-        bare_rpms = set(rpms)
+        have_pkgs = set(have_rpms)
     else:
-        bare_rpms = set(map(arch_strip, rpms))
+        have_pkgs = set(map(arch_strip, have_rpms))
 
-    match_rpms = set(pkgs)
-    missing_rpms = match_rpms - bare_rpms
+    want_pkgs = set(want_pkgs)
+    missing_pkgs = want_pkgs - have_pkgs
 
-    if not pkgs:
-        all_match_rpms = rpms
+    if not want_pkgs:
+        display_rpms = have_rpms
     elif strip_arch:
-        all_match_rpms = match_rpms
+        display_rpms = want_pkgs
     else:
-        matching_rpms = set(x for x in rpms if arch_strip(x) in match_rpms)
-        all_match_rpms = matching_rpms | missing_rpms
+        matching_rpms = set(x for x in have_rpms if arch_strip(x) in want_pkgs)
+        display_rpms = matching_rpms | missing_pkgs
 
-    display_pkgs = sorted(all_match_rpms)
+    display_rpms = sorted(display_rpms)
 
-    return [ [pkg, rpms.get(pkg, '-')] for pkg in display_pkgs ]
+    return [ [rpm, have_rpms.get(rpm, '-')] for rpm in display_rpms ]
 
 def display_single_output(output, pkgs):
     pkg_vrs = single_output_pkg_vrs(output, pkgs)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -75,6 +75,9 @@ def parseargs():
     outdir = args[0]
     pkgs   = args[1:]
 
+    if max_nums < 0:
+        max_nums = 99999
+
     if summarize and not pkgs:
         usage("Must specify package list for --summarize")
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -164,13 +164,15 @@ def single_output_pkg_vrs(output, pkgs):
     match_rpms = set(pkgs)
     missing_rpms = match_rpms - bare_rpms
 
-    if strip_arch:
+    if not pkgs:
+        all_match_rpms = rpms
+    elif strip_arch:
         all_match_rpms = match_rpms
     else:
         matching_rpms = set(x for x in rpms if arch_strip(x) in match_rpms)
         all_match_rpms = matching_rpms | missing_rpms
 
-    display_pkgs = sorted(all_match_rpms if pkgs else rpms)
+    display_pkgs = sorted(all_match_rpms)
 
     return [ [pkg, rpms.get(pkg, '-')] for pkg in display_pkgs ]
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -50,8 +50,7 @@ dist_pat = r'((\.osg(\d+)?)?\.[es]l[5-9](_[\d.]+)?(\.centos)?|\.osg|\.fc\d+)$'
 
 def usage(msg=None):
     if msg:
-        print msg
-        print
+        print "***", msg, "***"
     print __doc__ % {"script": os.path.basename(__file__)}
     sys.exit()
 
@@ -227,7 +226,6 @@ def get_run_output_dirs(rundir):
 
     return outputs
 
-
 def summarize_outputs(rundir, pkgs):
     outputs = get_run_output_dirs(rundir)
 
@@ -263,8 +261,8 @@ if __name__ == '__main__':
     try:
         main()
     except RuntimeError as e:
-        print >>sys.stderr, "Error: %s" % e.message
+        print >>sys.stderr, "Error: %s" % e
         sys.exit(1)
     except getopt.GetoptError as e:
-        usage(e.msg)
+        usage(e)
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -23,9 +23,11 @@ Options:
 
   -s, --summarize      summarize results for all output subdirs
   -l, --list-outputs   list output numbers (summarize mode only)
+  -L, --max-outputs N  list at most N output numbers per NVR (-1 for unlimited)
 """
 
 import collections
+import getopt
 import glob
 import stat
 import sys
@@ -54,18 +56,24 @@ def usage(msg=None):
     sys.exit()
 
 def parseargs():
-    global strip_arch, strip_dist, outdir, summarize, list_nums
-    for arg in sys.argv[1:]:
-        if   arg in ('-A', '--no-strip-arch') : strip_arch = False
-        elif arg in ('-D', '--no-strip-dist') : strip_dist = False
-        elif arg in ('-s', '--summarize')     : summarize  = True
-        elif arg in ('-l', '--list-outputs')  : list_nums  = True
-        elif arg.startswith('-')              : usage()
-        elif outdir is None                   : outdir = arg
-        else                                  : pkgs.append(arg)
+    global outdir, pkgs, strip_arch, strip_dist, summarize, list_nums, max_nums
+    longopts = ['no-strip-arch', 'no-strip-dist', 'summarize',
+                'list-outputs', 'max-outputs=', 'help']
+    ops,args = getopt.getopt(sys.argv[1:], 'ADslL:', longopts)
+    for op,val in ops:
+        if   op in ('-A', '--no-strip-arch') : strip_arch = False
+        elif op in ('-D', '--no-strip-dist') : strip_dist = False
+        elif op in ('-s', '--summarize')     : summarize  = True
+        elif op in ('-l', '--list-outputs')  : list_nums  = True
+        elif op in ('-L', '--max-outputs')   : list_nums  = True; \
+                                               max_nums   = int(val)
+        elif op == '--help'                  : usage()
 
-    if outdir is None:
+    if not args:
         usage("Must provide a test run output location")
+
+    outdir = args[0]
+    pkgs   = args[1:]
 
     if summarize and not pkgs:
         usage("Must specify package list for --summarize")
@@ -256,4 +264,6 @@ if __name__ == '__main__':
     except RuntimeError as e:
         print >>sys.stderr, "Error: %s" % e.message
         sys.exit(1)
+    except getopt.GetoptError as e:
+        usage(e.msg)
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -31,7 +31,10 @@ strip_dist = True
 arch_pat = r'\.(x86_64|i[3-6]86|noarch|src)$'
 dist_pat = r'((\.osg(\d+)?)?\.[es]l[5-9](_[\d.]+)?(\.centos)?|\.osg|\.fc\d+)$'
 
-def usage():
+def usage(msg=None):
+    if msg:
+        print msg
+        print
     print __doc__ % os.path.basename(__file__)
     sys.exit()
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -232,18 +232,16 @@ def summarize_outputs(rundir, pkgs):
     for output in outputs:
         pkg_vrs = single_output_pkg_vrs(output, pkgs)
         for pkg,vr in pkg_vrs:
-            pkgstats[pkg][vr]["count"] += 1
-            if list_nums:
-                pkgstats[pkg][vr]["outputs"] += [outputnum(output)]
+            pkgstats[pkg][vr] += [outputnum(output)]
 
     header = get_summary_header()
     pkgstatslist = []
     for pkg in sorted(pkgstats):
         for vr in sorted(pkgstats[pkg], cmp=rpmvercmp):
-            row = [pkg, vr, str(pkgstats[pkg][vr]["count"])]
+            row = [pkg, vr, str(len(pkgstats[pkg][vr]))]
             if list_nums:
-                nums_str =','.join(pkgstats[pkg][vr]["outputs"][:max_nums])
-                if len(pkgstats[pkg][vr]["outputs"]) > max_nums:
+                nums_str =','.join(pkgstats[pkg][vr][:max_nums])
+                if len(pkgstats[pkg][vr]) > max_nums:
                     nums_str += ",..."
                 row.append(nums_str)
             pkgstatslist.append(row)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -217,7 +217,7 @@ def get_run_output_dirs(rundir):
         rundir = "%s/run-%s" % (GLOBAL_RUNS_DIR, rundir)
 
     globpat = "%s/output-[0-9][0-9][0-9]*/" % rundir
-    outputs = glob.glob(globpat)
+    outputs = sorted(glob.glob(globpat))
 
     if not outputs:
         raise RuntimeError("no output dirs found under '%s'" % rundir)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -167,8 +167,8 @@ def single_output_pkg_vrs(output, pkgs):
     if strip_arch:
         all_match_rpms = match_rpms
     else:
-        all_match_rpms = ( set(x for x in rpms if arch_strip(x) in match_rpms)
-                         | missing_rpms )
+        matching_rpms = set(x for x in rpms if arch_strip(x) in match_rpms)
+        all_match_rpms = matching_rpms | missing_rpms
 
     display_pkgs = sorted(all_match_rpms if pkgs else rpms)
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -97,8 +97,7 @@ def nvrmap(output):
         globpat = "%s/output/osg-test-*.log" % output
         log = glob.glob(globpat)
         if len(log) != 1:
-            print >>sys.stderr, "Error: could not find '%s'" % globpat
-            sys.exit(1)
+            raise RuntimeError("could not find '%s'" % globpat)
         log = log[0]
 
     # split this way since there can be more than one item per line
@@ -155,5 +154,9 @@ def main():
     display_single_output(outdir, pkgs)
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except RuntimeError as e:
+        print >>sys.stderr, "Error: %s" % e.message
+        sys.exit(1)
 

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -101,12 +101,6 @@ def nvrgen(items):
         yield [na,evr]
         items[:2] = []
 
-def isdir(fn):
-    try:
-        return stat.S_ISDIR(os.stat(fn).st_mode)
-    except OSError:
-        return False
-
 def rpm_qa2na_vr(line):
     line = re.sub(r'(\.rpm)?\r?\n?$', '', line)
     if re.search(arch_pat, line):
@@ -124,7 +118,7 @@ def rpm_qa2na_vr(line):
     return [na,vr]
 
 def nvrmap(output):
-    if not isdir(output):
+    if not os.path.isdir(output):
         log = output
     else:
         globpat = "%s/output/osg-test-*.log" % output
@@ -211,7 +205,7 @@ def get_summary_header():
     return header
 
 def get_run_output_dirs(rundir):
-    if isdir(rundir):
+    if os.path.isdir(rundir):
         pass  # OK, specified path exists
     elif re.match(r'run-20[0-9]{6}-[0-9]{4}$', rundir):
         rundir = "%s/%s" % (GLOBAL_RUNS_DIR, rundir)

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -35,15 +35,17 @@ def usage():
     print __doc__ % os.path.basename(__file__)
     sys.exit()
 
-for arg in sys.argv[1:]:
-    if   arg in ('-A', '--no-strip-arch') : strip_arch = False
-    elif arg in ('-D', '--no-strip-dist') : strip_dist = False
-    elif arg.startswith('-')              : usage()
-    elif outdir is None                   : outdir = arg
-    else                                  : pkgs.append(arg)
+def parseargs():
+    global strip_arch, strip_dist, outdir
+    for arg in sys.argv[1:]:
+        if   arg in ('-A', '--no-strip-arch') : strip_arch = False
+        elif arg in ('-D', '--no-strip-dist') : strip_dist = False
+        elif arg.startswith('-')              : usage()
+        elif outdir is None                   : outdir = arg
+        else                                  : pkgs.append(arg)
 
-if outdir is None:
-    usage()
+    if outdir is None:
+        usage()
 
 def arch_strip(na):
     return re.sub(arch_pat, '', na)
@@ -149,6 +151,7 @@ def display_single_output(output, pkgs):
     print_table(["Package", output], pkg_vrs)
 
 def main():
+    parseargs()
     display_single_output(outdir, pkgs)
 
 if __name__ == '__main__':

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -17,16 +17,21 @@ Options:
   -D, --no-strip-dist  don't attempt to strip .dist tag from package releases
 """
 
+import collections
 import glob
 import stat
 import sys
 import os
 import re
 
+
+GLOBAL_RUNS_DIR = "/osgtest/runs"
+
 outdir     = None
 pkgs       = []
 strip_arch = True
 strip_dist = True
+summarize  = False
 
 arch_pat = r'\.(x86_64|i[3-6]86|noarch|src)$'
 dist_pat = r'((\.osg(\d+)?)?\.[es]l[5-9](_[\d.]+)?(\.centos)?|\.osg|\.fc\d+)$'
@@ -39,16 +44,20 @@ def usage(msg=None):
     sys.exit()
 
 def parseargs():
-    global strip_arch, strip_dist, outdir
+    global strip_arch, strip_dist, outdir, summarize
     for arg in sys.argv[1:]:
         if   arg in ('-A', '--no-strip-arch') : strip_arch = False
         elif arg in ('-D', '--no-strip-dist') : strip_dist = False
+        elif arg in ('-s', '--summarize')     : summarize  = True
         elif arg.startswith('-')              : usage()
         elif outdir is None                   : outdir = arg
         else                                  : pkgs.append(arg)
 
     if outdir is None:
-        usage()
+        usage("Must provide a test run output location")
+
+    if summarize and not pkgs:
+        usage("Must specify package list for --summarize")
 
 def arch_strip(na):
     return re.sub(arch_pat, '', na)
@@ -152,9 +161,57 @@ def display_single_output(output, pkgs):
     pkg_vrs = single_output_pkg_vrs(output, pkgs)
     print_table(["Package", output], pkg_vrs)
 
+class autodict(collections.defaultdict):
+    def __init__(self,*other):
+        collections.defaultdict.__init__(self, self.__class__, *other)
+    def __add__ (self, other):
+        return other
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, dict.__repr__(self))
+
+try:
+    import rpm
+    from rpmUtils.miscutils import stringToVersion
+    def rpmvercmp(a,b):
+        return rpm.labelCompare(*[stringToVersion(x) for x in (a,b)])
+except ImportError:
+    rpmvercmp = None
+
+def summarize_outputs(rundir, pkgs):
+    if isdir(rundir):
+        pass  # OK, specified path exists
+    elif re.match(r'run-20[0-9]{6}-[0-9]{4}$', rundir):
+        rundir = "%s/%s" % (GLOBAL_RUNS_DIR, rundir)
+    elif re.match(r'20[0-9]{6}-[0-9]{4}$', rundir):
+        rundir = "%s/run-%s" % (GLOBAL_RUNS_DIR, rundir)
+
+    globpat = "%s/output-[0-9][0-9][0-9]*/" % rundir
+    outputs = glob.glob(globpat)
+
+    if not outputs:
+        raise RuntimeError("no output dirs found under '%s'" % rundir)
+
+    pkgstats = autodict()
+
+    for output in outputs:
+        pkg_vrs = single_output_pkg_vrs(output, pkgs)
+        for pkg,vr in pkg_vrs:
+            pkgstats[pkg][vr] += 1
+
+    pkgstatslist = []
+    for pkg in sorted(pkgstats):
+        for vr in sorted(pkgstats[pkg], cmp=rpmvercmp):
+            pkgstatslist.append([pkg, vr, str(pkgstats[pkg][vr])])
+        pkgstatslist.append(['', '', ''])
+
+    print_table(["Package", "Version-Release", "Count"], pkgstatslist)
+
 def main():
     parseargs()
-    display_single_output(outdir, pkgs)
+    if summarize:
+        summarize_outputs(outdir, pkgs)
+    else:
+        display_single_output(outdir, pkgs)
 
 if __name__ == '__main__':
     try:

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+
+"""
+Usage:
+  %s [options] output-001 [packages...]
+
+List version-release numbers for RPMs installed in an osg-test run output
+directory, as found in output-NNN/output/osg-test-*.log
+
+The output argument can also be a root.log from a koji/mock build,
+or the raw output of an 'rpm -qa' command.
+
+If any packages are specified, limit the results to just those packages.
+
+Options:
+  -A, --no-strip-arch  don't attempt to strip .arch from package names
+  -D, --no-strip-dist  don't attempt to strip .dist tag from package releases
+"""
+
+import glob
+import stat
+import sys
+import os
+import re
+
+outdir     = None
+pkgs       = []
+strip_arch = True
+strip_dist = True
+
+arch_pat = r'\.(x86_64|i[3-6]86|noarch|src)$'
+dist_pat = r'((\.osg(\d+)?)?\.[es]l[5-9](_[\d.]+)?(\.centos)?|\.osg|\.fc\d+)$'
+
+def usage():
+    print __doc__ % os.path.basename(__file__)
+    sys.exit()
+
+for arg in sys.argv[1:]:
+    if   arg in ('-A', '--no-strip-arch') : strip_arch = False
+    elif arg in ('-D', '--no-strip-dist') : strip_dist = False
+    elif arg.startswith('-')              : usage()
+    elif outdir is None                   : outdir = arg
+    else                                  : pkgs.append(arg)
+
+if outdir is None:
+    usage()
+
+def arch_strip(na):
+    return re.sub(arch_pat, '', na)
+
+def dist_strip(evr):
+    ev,r = evr.split('-')
+    r = re.sub(dist_pat, '', r)
+    return '-'.join([ev,r])
+
+def nvrgen(items):
+    # generate sequence of ["name.arch", "epoch:version-release"] pairs
+    while items:
+        na, evr = items[:2]
+        if strip_arch:
+            na = arch_strip(na)
+        if strip_dist:
+            evr = dist_strip(evr)
+        if evr.startswith("0:"):
+            evr = evr[2:]
+        yield [na,evr]
+        items[:2] = []
+
+def isdir(fn):
+    try:
+        return stat.S_ISDIR(os.stat(fn).st_mode)
+    except OSError:
+        return False
+
+def rpm_qa2na_vr(line):
+    line = re.sub(r'(\.rpm)?\r?\n?$', '', line)
+    if re.search(arch_pat, line):
+        nvr,a = line.rsplit('.', 1)
+    else:
+        nvr,a = line, None
+    n,v,r = nvr.rsplit('-',2)
+    if a and not strip_arch:
+        na = '.'.join((n,a))
+    else:
+        na = n
+    if strip_dist:
+        r = re.sub(dist_pat, '', r)
+    vr = '-'.join((v,r))
+    return [na,vr]
+
+def nvrmap(output):
+    if not isdir(output):
+        log = output
+    else:
+        globpat = "%s/output/osg-test-*.log" % output
+        log = glob.glob(globpat)
+        if len(log) != 1:
+            print >>sys.stderr, "Error: could not find '%s'" % globpat
+            sys.exit(1)
+        log = log[0]
+
+    # split this way since there can be more than one item per line
+    txt = open(log).read()
+    if ' ' in txt:
+        # strip "DEBUG util.py:388:  " in case this is coming from a root.log
+        txt = re.sub(r'\n[A-Z]+ .*?:\d+:  ', r'\n', txt)
+        # don't include Install list from cleanup/downgrade
+        txt = re.sub(r'\nosgtest: .* special_cleanup[\d\D]*', r'\n', txt)
+        items_pat = (r'^(?:Dependency )?(?:Installed|Updated|Replaced):\n'
+                     r'(.*?)\n(?:\n|(?=[^ ]))')
+        items = ' '.join(re.findall(items_pat, txt, re.S | re.M)).split()
+        return dict(nvrgen(items))
+    else:
+        # at most 1-word per line; assume this is 'rpm -qa' output
+        return dict(map(rpm_qa2na_vr, txt.split()))
+
+def print_table(headercol, table):
+    table = [headercol] + table
+    widths = [ max(map(len,col)) for col in zip(*table) ]
+    table[1:1] = [[ '-' * n for n in widths ]]
+    for i,row in enumerate(table):
+        spacing = [ w-len(x) for x,w in zip(row,widths) ]
+        print '  '.join( r + ' ' * s for r,s in zip(row,spacing) ).rstrip()
+
+def single_output(output, pkgs):
+    rpms = nvrmap(output)
+
+    if strip_arch:
+        bare_rpms = set(rpms)
+    else:
+        bare_rpms = set(map(arch_strip, rpms))
+
+    match_rpms = set(pkgs)
+
+    if strip_arch:
+        all_match_rpms = match_rpms
+    else:
+        all_match_rpms = set(x for x in rpms if arch_strip(x) in match_rpms)
+
+    pkg_vrs = []
+    for pkg in sorted(all_match_rpms if pkgs else rpms):
+        vr = rpms.get(pkg) or '-'
+        pkg_vrs.append([pkg, vr])
+
+    print_table(["Package", output], pkg_vrs)
+
+
+def main():
+    single_output(outdir, pkgs)
+
+if __name__ == '__main__':
+    main()
+

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -20,7 +20,9 @@ subdirectories for that set of osg test runs.
 Options:
   -A, --no-strip-arch  don't attempt to strip .arch from package names
   -D, --no-strip-dist  don't attempt to strip .dist tag from package releases
+
   -s, --summarize      summarize results for all output subdirs
+  -l, --list-outputs   list output numbers (summarize mode only)
 """
 
 import collections
@@ -38,6 +40,8 @@ pkgs       = []
 strip_arch = True
 strip_dist = True
 summarize  = False
+list_nums  = False
+max_nums   = 7
 
 arch_pat = r'\.(x86_64|i[3-6]86|noarch|src)$'
 dist_pat = r'((\.osg(\d+)?)?\.[es]l[5-9](_[\d.]+)?(\.centos)?|\.osg|\.fc\d+)$'
@@ -50,11 +54,12 @@ def usage(msg=None):
     sys.exit()
 
 def parseargs():
-    global strip_arch, strip_dist, outdir, summarize
+    global strip_arch, strip_dist, outdir, summarize, list_nums
     for arg in sys.argv[1:]:
         if   arg in ('-A', '--no-strip-arch') : strip_arch = False
         elif arg in ('-D', '--no-strip-dist') : strip_dist = False
         elif arg in ('-s', '--summarize')     : summarize  = True
+        elif arg in ('-l', '--list-outputs')  : list_nums  = True
         elif arg.startswith('-')              : usage()
         elif outdir is None                   : outdir = arg
         else                                  : pkgs.append(arg)
@@ -133,10 +138,10 @@ def nvrmap(output):
         # at most 1-word per line; assume this is 'rpm -qa' output
         return dict(map(rpm_qa2na_vr, txt.split()))
 
-def print_table(headercol, table):
-    table = [headercol] + table
+def print_table(header, table):
+    table = [header] + table
     widths = [ max(map(len,col)) for col in zip(*table) ]
-    table[1:1] = [[ '-' * n for n in widths ]]
+    table[1:1] = [[ '-' * n for n in map(len,header) ]]
     for i,row in enumerate(table):
         spacing = [ w-len(x) for x,w in zip(row,widths) ]
         print '  '.join( r + ' ' * s for r,s in zip(row,spacing) ).rstrip()
@@ -165,7 +170,8 @@ def single_output_pkg_vrs(output, pkgs):
 
 def display_single_output(output, pkgs):
     pkg_vrs = single_output_pkg_vrs(output, pkgs)
-    print_table(["Package", output], pkg_vrs)
+    name_field = "Package" if strip_arch else "Package.Arch"
+    print_table([name_field, output], pkg_vrs)
 
 class autodict(collections.defaultdict):
     def __init__(self,*other):
@@ -183,7 +189,18 @@ try:
 except ImportError:
     rpmvercmp = None
 
-def summarize_outputs(rundir, pkgs):
+def outputnum(output):
+    m = re.search(r'(?:/|^)output-(\d+)/?', output)
+    return m.group(1) if m else output
+
+def get_summary_header():
+    name_field = "Package" if strip_arch else "Package.Arch"
+    header = [name_field, "Version-Release", "Count"]
+    if list_nums:
+        header.append("Output-Nums")
+    return header
+
+def get_run_output_dirs(rundir):
     if isdir(rundir):
         pass  # OK, specified path exists
     elif re.match(r'run-20[0-9]{6}-[0-9]{4}$', rundir):
@@ -197,20 +214,34 @@ def summarize_outputs(rundir, pkgs):
     if not outputs:
         raise RuntimeError("no output dirs found under '%s'" % rundir)
 
-    pkgstats = autodict()
+    return outputs
 
+
+def summarize_outputs(rundir, pkgs):
+    outputs = get_run_output_dirs(rundir)
+
+    pkgstats = autodict()
     for output in outputs:
         pkg_vrs = single_output_pkg_vrs(output, pkgs)
         for pkg,vr in pkg_vrs:
-            pkgstats[pkg][vr] += 1
+            pkgstats[pkg][vr]["count"] += 1
+            if list_nums:
+                pkgstats[pkg][vr]["outputs"] += [outputnum(output)]
 
+    header = get_summary_header()
     pkgstatslist = []
     for pkg in sorted(pkgstats):
         for vr in sorted(pkgstats[pkg], cmp=rpmvercmp):
-            pkgstatslist.append([pkg, vr, str(pkgstats[pkg][vr])])
-        pkgstatslist.append(['', '', ''])
+            row = [pkg, vr, str(pkgstats[pkg][vr]["count"])]
+            if list_nums:
+                nums_str =','.join(pkgstats[pkg][vr]["outputs"][:max_nums])
+                if len(pkgstats[pkg][vr]["outputs"]) > max_nums:
+                    nums_str += ",..."
+                row.append(nums_str)
+            pkgstatslist.append(row)
+        pkgstatslist.append([''] * len(header))
 
-    print_table(["Package", "Version-Release", "Count"], pkgstatslist)
+    print_table(header, pkgstatslist)
 
 def main():
     parseargs()

--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -122,31 +122,34 @@ def print_table(headercol, table):
         spacing = [ w-len(x) for x,w in zip(row,widths) ]
         print '  '.join( r + ' ' * s for r,s in zip(row,spacing) ).rstrip()
 
-def single_output(output, pkgs):
+def single_output_pkg_vrs(output, pkgs):
     rpms = nvrmap(output)
 
+    # arch-stripped rpm names
     if strip_arch:
         bare_rpms = set(rpms)
     else:
         bare_rpms = set(map(arch_strip, rpms))
 
     match_rpms = set(pkgs)
+    missing_rpms = match_rpms - bare_rpms
 
     if strip_arch:
         all_match_rpms = match_rpms
     else:
-        all_match_rpms = set(x for x in rpms if arch_strip(x) in match_rpms)
+        all_match_rpms = ( set(x for x in rpms if arch_strip(x) in match_rpms)
+                         | missing_rpms )
 
-    pkg_vrs = []
-    for pkg in sorted(all_match_rpms if pkgs else rpms):
-        vr = rpms.get(pkg) or '-'
-        pkg_vrs.append([pkg, vr])
+    display_pkgs = sorted(all_match_rpms if pkgs else rpms)
 
+    return [ [pkg, rpms.get(pkg, '-')] for pkg in display_pkgs ]
+
+def display_single_output(output, pkgs):
+    pkg_vrs = single_output_pkg_vrs(output, pkgs)
     print_table(["Package", output], pkg_vrs)
 
-
 def main():
-    single_output(outdir, pkgs)
+    display_single_output(outdir, pkgs)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This was taken largely from [`compare-rpm-versions`](https://github.com/opensciencegrid/tools/blob/master/compare-rpm-versions) script, which was really designed for comparing rpm versions between two different osg test runs (or two different root.logs, or two different rpm -qa outputs).

What it lacked (which this new script provides) is to simply list the versions of particular packages for a single run, or to summarize that information across all output dirs for a set of runs.

This is intended to be installed and run from osghost, but it can be run against local copies of data also (an entire osg test run-DATE dir, a single output-NNN dir, a root.log, or an rpm -qa output).

Time flies when you're up coding instead of sleeping...