### PR TITLE
Allow non-ff updates for matyas's wip/* branches

### DIFF
--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -50,6 +50,10 @@ initrepo () {
 
     # allow non-ff pull request updates, and ff-only updates for all other refs
     git config remote.origin.fetch '+refs/pull/*:refs/pull/*'
+    # matyas reserves the right to force-push to wip/* branches
+    if [[ $remote =~ matyasselmeci ]]; then
+        git config --add remote.origin.fetch '+refs/wip/*:refs/wip/*'
+    fi
     git config --add remote.origin.fetch 'refs/*:refs/*'
   )
 }

--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -50,10 +50,7 @@ initrepo () {
 
     # allow non-ff pull request updates, and ff-only updates for all other refs
     git config remote.origin.fetch '+refs/pull/*:refs/pull/*'
-    # matyas reserves the right to force-push to wip/* branches
-    if [[ $remote =~ matyasselmeci ]]; then
-        git config --add remote.origin.fetch '+refs/wip/*:refs/wip/*'
-    fi
+    git config --add remote.origin.fetch '+refs/heads/wip/*:refs/heads/wip/*'
     git config --add remote.origin.fetch 'refs/*:refs/*'
   )
 }


### PR DESCRIPTION
I don't really like adding user-specific code but the `wip/*` convention is serving me well, and I have a repo (dask_condor) that really ought to be backed up.