### PR TITLE
use python-jira module for jira status emailer

### DIFF
--- a/jira-ticket-summary
+++ b/jira-ticket-summary
@@ -5,7 +5,7 @@ import smtplib
 import time
 from jira.client import JIRA
 
-FROM = 'Tim Cartwright <cat@cs.wisc.edu>'
+FROM = 'JIRA Ticket Summary <cndrutil@cs.wisc.edu>'
 RECIPIENTS = (
     'Tim Cartwright <cat@cs.wisc.edu>',
     'Brian Lin <blin@cs.wisc.edu>',

--- a/jira-ticket-summary
+++ b/jira-ticket-summary
@@ -26,7 +26,7 @@ def mail_message(subject, message, recipients):
             +   '\r\n'
             +   message )
     smtp = smtplib.SMTP('localhost')
-    smtp.sendmail(from_addr, recipients, payload)
+    smtp.sendmail(FROM, recipients, payload)
     smtp.quit()
 
 

--- a/jira-ticket-summary
+++ b/jira-ticket-summary
@@ -1,11 +1,9 @@
 #!/usr/bin/python
 
-# Originally written by Carl Edquist; hacked to bits by Tim Cartwright.
-
 import re
 import smtplib
 import time
-import urllib2
+from jira.client import JIRA
 
 FROM = 'Tim Cartwright <cat@cs.wisc.edu>'
 RECIPIENTS = (
@@ -13,9 +11,12 @@ RECIPIENTS = (
     'Brian Lin <blin@cs.wisc.edu>',
     'Mat Selmeci <matyas+cron@cs.wisc.edu>',
 )
+PROJECT = 'SOFTWARE'
+STATUSES = ('Open', 'In Progress', 'Ready for Testing', 'Ready for Release')
+URL = 'https://opensciencegrid.atlassian.net'
 
-HEADERS = ('Open', 'In Progress', 'Ready for Testing', 'Ready for Release')
-URL = 'http://opensciencegrid.atlassian.net/projects/SOFTWARE/summary/statistics'
+jira = JIRA(URL)
+
 
 # Adapted from Mat's aggregator/emailer.py script
 def mail_message(subject, message, recipients):
@@ -28,15 +29,16 @@ def mail_message(subject, message, recipients):
     smtp.sendmail(from_addr, recipients, payload)
     smtp.quit()
 
-html = urllib2.urlopen(URL).read()
+
+def project_status_total(project, status):
+    search = 'project = {} AND status = "{}"'.format(project, status)
+    return jira.search_issues(search, maxResults=0).total
+
 
 text = 'JIRA Software tickets:\n\n'
-for h in HEADERS:
-    m = re.search(r'>%s<.*?<td class="cell-type-collapsed">(\d+)</td>' % h, html, re.S)
-    if m:
-        text += '    * %s: %s ()\n' % (h, m.groups()[0])
-    else:
-        text += '    * %s: 0 ()\n' % (h)
+for status in STATUSES:
+    count = project_status_total(PROJECT, status)
+    text += '    * %s: %s ()\n' % (status, count)
 text += '\n'
 text += 'Completed at %s\n' % (time.strftime('%Y-%m-%d %H:%M'))
 

--- a/jira-ticket-summary
+++ b/jira-ticket-summary
@@ -7,18 +7,23 @@ import smtplib
 import time
 import urllib2
 
-RECIPIENTS = ('Tim Cartwright <cat@cs.wisc.edu>', 'Brian Lin <blin@cs.wisc.edu>', 'Mat Selmeci <matyas+cron@cs.wisc.edu>')
+FROM = 'Tim Cartwright <cat@cs.wisc.edu>'
+RECIPIENTS = (
+    'Tim Cartwright <cat@cs.wisc.edu>',
+    'Brian Lin <blin@cs.wisc.edu>',
+    'Mat Selmeci <matyas+cron@cs.wisc.edu>',
+)
+
 HEADERS = ('Open', 'In Progress', 'Ready for Testing', 'Ready for Release')
 URL = 'http://opensciencegrid.atlassian.net/projects/SOFTWARE/summary/statistics'
 
 # Adapted from Mat's aggregator/emailer.py script
 def mail_message(subject, message, recipients):
-    from_addr = 'Tim Cartwright <cat@cs.wisc.edu>'
-    payload = 'Subject: %s\r\n' % (subject)
-    payload += 'From: %s\r\n' % (from_addr)
-    payload += 'To: %s\r\n' % (', '.join(recipients))
-    payload += '\r\n'
-    payload += message
+    payload = ( 'Subject: %s\r\n' % subject
+            +   'From: %s\r\n' % FROM
+            +   'To: %s\r\n' % ', '.join(recipients)
+            +   '\r\n'
+            +   message )
     smtp = smtplib.SMTP('localhost')
     smtp.sendmail(from_addr, recipients, payload)
     smtp.quit()

--- a/venv-run
+++ b/venv-run
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+usage () {
+  echo "usage: $(basename "$0") venv-dir python-script [args...]" >&2
+  echo
+  echo "Run python-script under venv environment."
+  exit 1
+}
+
+[[ -d $1 ]] || usage
+
+. "$1"/bin/activate
+shift
+python "$@"
+


### PR DESCRIPTION
Our new fangled jira doesn't have the same raw html page for scraping statuses.  Oh well.  Maybe the jira module is cleaner anyway.

NOTE - the python-jira module will need to be installed where this script is run.