### PR TITLE
move ghmeta working copy to local disk on moria (SOFTWARE-3726)

### DIFF
--- a/github/github-metadata-backup.sh
+++ b/github/github-metadata-backup.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
+set -e
 
 topdir=/p/condor/workspaces/vdt/git
 ghmdir=$topdir/github_meta
 logdir=$topdir/log
 srcdir=$topdir/script
+local_ghmdir=$HOME/github_meta
 
+# due to the enormous number of files involved:
+#   - origin bare repo on AFS is $ghmdir/repos.git
+#   - working copy is on local disk under $local_ghmdir
 
 # Note:
 #   - pyjwt and PyGithub libs installed locally on moria under ~/.local/lib
 #   - See ~/git/ for the versions installed, with: ./setup.py build;
 #                                                  ./setup.py install --user
 
-cd $ghmdir
+cd "$local_ghmdir"
 
 /usr/bin/stdbuf -oL \
 $srcdir/ghb.py opensciencegrid $ghmdir/token >$logdir/ghmeta_backup.log \
@@ -22,5 +27,6 @@ cd repos/
 git add .
 if [[ $(git status --porcelain) ]]; then
   git commit -qm auto-bak
+  git push
 fi
 

--- a/github/github-metadata-backup.sh
+++ b/github/github-metadata-backup.sh
@@ -5,8 +5,11 @@ ghmdir=$topdir/github_meta
 logdir=$topdir/log
 srcdir=$topdir/script
 
-# PyGithub and pyjwt libs installed locally on moria under ~/.local/lib
-#export PYTHONPATH=$HOME/.local_python/lib/python2.6/site-packages/
+
+# Note:
+#   - pyjwt and PyGithub libs installed locally on moria under ~/.local/lib
+#   - See ~/git/ for the versions installed, with: ./setup.py build;
+#                                                  ./setup.py install --user
 
 cd $ghmdir
 


### PR DESCRIPTION
there are some 30k+ files in the working copy, and statting them is slow as molasses on AFS.  Compromise by having the working copy on local disk (on moria), and the important part (the 'origin' git bare repo) still on AFS.