### PR TITLE
add PAT support for git-hubber

### DIFF
--- a/github/git-hubber
+++ b/github/git-hubber
@@ -39,6 +39,7 @@ COMMANDs:
   (*)   unprotect-branch OWNER REPO BRANCH
         list-prs         OWNER REPO
   (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH TITLE BODY
+  (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH {TITLE BODY|ISSUE}
   (*)   merge-pr         OWNER REPO NUMBER
   (*)   close-pr         OWNER REPO NUMBER
   (*)   list-hooks       OWNER REPO
@@ -76,6 +77,7 @@ options = Options()
 def add_gh_preview_header(req):
     req.add_header("Accept", "application/vnd.github.loki-preview+json")
     req.add_header("Accept", "application/vnd.github.mercy-preview+json")
+    req.add_header("Accept", "application/vnd.github.v3+json")
 
 def add_auth_header(req):
     if options.token:
@@ -155,7 +157,8 @@ github API notes:
 : protect-branch PATCH /repos/:owner/:repo/branches/:branch {"enabled": "true"}
 : request-pull   POST /repos/:owner/:repo/pulls {
                       "title": "New Feature", "body": "PR description",
-                      "base": "master", "head": "someuser:somebranch"}
+                      "base": "master", "head": "someuser:somebranch",
+                      "issue": 123}
 : merge-pr       PUT /repos/:owner/:repo/pulls/:number/merge
                  # {"commit_title": "title", "commit_message": "desc"}
 : close-pr       PATCH /repos/:owner/:repo/pulls/:number {"state": "closed"}
@@ -276,7 +279,7 @@ def close_pr(owner, repo, number):
     snarfer(PATCH, "/repos/%s/%s/pulls/%s" % (owner, repo, number),
            {"state": "closed"})
 
-def request_pull(owner, baserepo, frombranch, title, body):
+def request_pull(owner, baserepo, frombranch, title, body=None):
     repo, base = baserepo.split(':')
 
     head = frombranch
@@ -284,8 +287,12 @@ def request_pull(owner, baserepo, frombranch, title, body):
         # probably an error
         pass
 
-    print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo),
-           {"title": title, "body": body, "head": head, "base": basebranch})])
+    if body is None:
+        data = {"head": head, "base": base, "issue": int(title)}
+    else:
+        data = {"head": head, "base": base, "title": title, "body": body}
+
+    print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
 
 def list_hooks(owner, repo):
     print_hook_info(snarfer(GET, '/repos/%s/%s/hooks' % (owner, repo)))

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -68,7 +68,7 @@ PATCH  = 'PATCH'
 DELETE = 'DELETE'
 
 class Options:
-    authstr = None
+    token = None
     show_headers = False
     listfields = ['html_url']
 
@@ -79,8 +79,8 @@ def add_gh_preview_header(req):
     req.add_header("Accept", "application/vnd.github.mercy-preview+json")
 
 def add_auth_header(req):
-    if options.authstr:
-        req.add_header("Authorization", "Basic %s" % options.authstr)
+    if options.token:
+        req.add_header("Authorization", "token %s" % options.token)
 
 def authsetup(user, passwd):
     from base64 import encodestring
@@ -371,7 +371,7 @@ def main(args):
 
     if user:
         user, passwd = getpw(user, passfd)
-        authsetup(user, passwd)
+        options.token = passwd
         global login_user
         login_user = user
     elif user_required:

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -382,10 +382,21 @@ def main(args):
 
     method(*args)
 
+def dump_http_error(e):
+    print >>sys.stderr, e
+    print >>sys.stderr, ""
+    if options.show_headers:
+        print >>sys.stderr, e.headers
+        print >>sys.stderr, ""
+    data = e.read()
+    if e.headers.gettype() == 'application/json':
+        data = json.loads(data) if data else None
+    print >>sys.stderr, json_pretty(data)
+
 if __name__ == '__main__':
     try:
         main(sys.argv[1:])
     except urllib2.HTTPError as e:
-        print >>sys.stderr, e
+        dump_http_error(e)
         sys.exit(1)
 

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -38,7 +38,7 @@ COMMANDs:
   (*)   protect-branch   OWNER REPO BRANCH
   (*)   unprotect-branch OWNER REPO BRANCH
         list-prs         OWNER REPO
-  (*)   request-pull     OWNER REPO[:BRANCH] [USER:]BRANCH TITLE BODY
+  (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH TITLE BODY
   (*)   merge-pr         OWNER REPO NUMBER
   (*)   close-pr         OWNER REPO NUMBER
   (*)   list-hooks       OWNER REPO
@@ -285,15 +285,12 @@ def close_pr(owner, repo, number):
            {"state": "closed"})
 
 def request_pull(owner, baserepo, frombranch, title, body):
-    if ':' in baserepo:
-        repo, basebranch = baserepo.split(':')
-    else:
-        repo, basebranch = baserepo, "master"
+    repo, base = baserepo.split(':')
 
-    if ':' in frombranch:
-        head = frombranch
-    else:
-        head = "%s:%s" % (login_user, frombranch)
+    head = frombranch
+    if ':' not in frombranch:
+        # probably an error
+        pass
 
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo),
            {"title": title, "body": body, "head": head, "base": basebranch})])
@@ -372,8 +369,6 @@ def main(args):
     if user:
         user, passwd = getpw(user, passfd)
         options.token = passwd
-        global login_user
-        login_user = user
     elif user_required:
         usage("USER required for %s command" % command)
 

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -74,10 +74,14 @@ class Options:
 
 options = Options()
 
+_accept = [
+    "application/vnd.github.loki-preview+json",
+    "application/vnd.github.mercy-preview+json",
+    "application/vnd.github.v3+json",
+]
+
 def add_gh_preview_header(req):
-    req.add_header("Accept", "application/vnd.github.loki-preview+json")
-    req.add_header("Accept", "application/vnd.github.mercy-preview+json")
-    req.add_header("Accept", "application/vnd.github.v3+json")
+    req.add_header("Accept", ", ".join(_accept))
 
 def add_auth_header(req):
     if options.token:

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -95,6 +95,9 @@ def getpw(pat, passfd=None):
     elif 'PASS' in os.environ:
         return os.environ['PASS']
 
+def json_pretty(data):
+    return json.dumps(data, sort_keys=True, indent=2)
+
 def linkparse(linktext):
     mm = re.findall(r'<([^>]+)>;\s*rel="([^"]+)"', linktext)
     return dict((page, rel) for rel,page in mm)
@@ -113,9 +116,13 @@ def _snarfer(method, url, data=None):
     req.get_method = lambda : method
     resp = urllib2.urlopen(req)
     if options.show_headers:
-        print "Headers for <%s>" % url
+        print "Response Headers for %s <%s>" % (method, url)
+        if data:
+            print "With data:"
+            print json_pretty(data)
         print "---"
         print resp.headers
+        print
     nextlink = get_nextlink(resp)
     return resp.read(), nextlink
 

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -294,19 +294,16 @@ def close_pr(owner, repo, number):
     snarfer(PATCH, "/repos/%s/%s/pulls/%s" % (owner, repo, number),
            {"state": "closed"})
 
-def request_pull(owner, baserepo, head, title, body):
+def request_pull_kw(owner, baserepo, head, **kw):
     repo, base = baserepo.split(':')
-
-    data = {"head": head, "base": base, "title": title, "body": body}
-
+    data = dict(head=head, base=base, **kw)
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
+
+def request_pull(owner, baserepo, head, title, body):
+    request_pull_kw(owner, baserepo, title=title, body=body)
 
 def request_pull_for_issue(owner, baserepo, head, issue)
-    repo, base = baserepo.split(':')
-
-    data = {"head": head, "base": base, "issue": int(issue)}
-
-    print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
+    request_pull_kw(owner, baserepo, issue=int(issue))
 
 def list_hooks(owner, repo):
     print_hook_info(snarfer(GET, '/repos/%s/%s/hooks' % (owner, repo)))

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -16,7 +16,7 @@ def usage(msg=None):
 
     s = os.path.basename(__file__)
     print """\
-usage: [PASS=...] %s [-u USER[:PASS]] [-d passfd] [-H] COMMAND [args...]
+usage: [PASS=...] %s [-p PASS] [-d passfd] [-H] COMMAND [args...]
 
 COMMANDs:
 
@@ -44,13 +44,12 @@ COMMANDs:
   (*)   list-hooks       OWNER REPO
   (*)   ping-hook        OWNER REPO HOOK_ID
         
-(*) USER login required
+(*) auth required
 
-PASS for USER is taken from the first of:
-  1. -u USER:PASS
+PASS (a github PAT) for auth is taken from the first of:
+  1. -p PASS
   2. -d passfd (read from fd)
   3. read from $PASS env var
-  4. read from terminal
 
 Options:
   -H   show http response headers
@@ -86,16 +85,13 @@ def authsetup(user, passwd):
     from base64 import encodestring
     options.authstr = encodestring('%s:%s' % (user,passwd)).replace('\n', '')
 
-def getpw(user, passfd=None):
-    if ':' in user:
-        user, pw = user.split(':', 1)
+def getpw(pat, passfd=None):
+    if pat:
+        return pat
     elif passfd is not None:
-        pw = os.fdopen(passfd).readline().rstrip('\n')
+        return os.fdopen(passfd).readline().rstrip('\n')
     elif 'PASS' in os.environ:
-        pw = os.environ['PASS']
-    else:
-        pw = getpass.getpass('passwd for user %s: ' % user)
-    return user, pw
+        return os.environ['PASS']
 
 def linkparse(linktext):
     mm = re.findall(r'<([^>]+)>;\s*rel="([^"]+)"', linktext)
@@ -302,7 +298,7 @@ def ping_hook(owner, repo, hook_id):
     snarfer(POST, "/repos/%s/%s/hooks/%s/pings" % (owner, repo, hook_id))
 
 methods = {
-#   'command-name':     [method,   user_required],
+#   'command-name':     [method,   auth_required],
     'list-mine':        [list_mine,        True],
     'list-user':        [list_user,        False],
     'list-org':         [list_org,         False],
@@ -342,15 +338,15 @@ def method_argcount_ok(method, args):
     return cmd_args - def_args <= len(args) <= cmd_args
 
 def main(args):
-    ops, args = getopt.getopt(args, 'u:d:HF:')
+    ops, args = getopt.getopt(args, 'p:d:HF:')
     ops = dict(ops)
     if len(args) < 1:
         usage()
 
-    user   = None
+    pat    = None
     passfd = None
 
-    if '-u' in ops: user   =     ops['-u']
+    if '-p' in ops: pat    =     ops['-p']
     if '-d' in ops: passfd = int(ops['-d'])
     if '-H' in ops: options.show_headers = True
     if '-F' in ops: options.listfields = checkfields(ops['-F'])
@@ -361,16 +357,14 @@ def main(args):
     if command not in methods:
         usage("unrecognized command: '%s'" % command)
 
-    method, user_required = methods[command]
+    method, auth_required = methods[command]
 
     if not method_argcount_ok(method, args):
         usage("wrong number of args for %s command" % command)
 
-    if user:
-        user, passwd = getpw(user, passfd)
-        options.token = passwd
-    elif user_required:
-        usage("USER required for %s command" % command)
+    options.token = getpw(pat)
+    if auth_required and not options.token:
+        usage("PASS required for %s command" % command)
 
     method(*args)
 

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -81,10 +81,6 @@ def add_auth_header(req):
     if options.token:
         req.add_header("Authorization", "token %s" % options.token)
 
-def authsetup(user, passwd):
-    from base64 import encodestring
-    options.authstr = encodestring('%s:%s' % (user,passwd)).replace('\n', '')
-
 def getpw(pat, passfd=None):
     if pat:
         return pat

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -294,25 +294,15 @@ def close_pr(owner, repo, number):
     snarfer(PATCH, "/repos/%s/%s/pulls/%s" % (owner, repo, number),
            {"state": "closed"})
 
-def request_pull(owner, baserepo, frombranch, title, body):
+def request_pull(owner, baserepo, head, title, body):
     repo, base = baserepo.split(':')
-
-    head = frombranch
-    if ':' not in frombranch:
-        # probably an error
-        pass
 
     data = {"head": head, "base": base, "title": title, "body": body}
 
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
 
-def request_pull_for_issue(owner, baserepo, frombranch, issue)
+def request_pull_for_issue(owner, baserepo, head, issue)
     repo, base = baserepo.split(':')
-
-    head = frombranch
-    if ':' not in frombranch:
-        # probably an error
-        pass
 
     data = {"head": head, "base": base, "issue": int(issue)}
 

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -294,16 +294,16 @@ def close_pr(owner, repo, number):
     snarfer(PATCH, "/repos/%s/%s/pulls/%s" % (owner, repo, number),
            {"state": "closed"})
 
-def request_pull_kw(owner, baserepo, head, **kw):
-    repo, base = baserepo.split(':')
+def request_pull_kw(owner, repo_base, head, **kw):
+    repo, base = repo_base.split(':')
     data = dict(head=head, base=base, **kw)
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
 
-def request_pull(owner, baserepo, head, title, body):
-    request_pull_kw(owner, baserepo, title=title, body=body)
+def request_pull(owner, repo_base, head, title, body):
+    request_pull_kw(owner, repo_base, title=title, body=body)
 
-def request_pull_for_issue(owner, baserepo, head, issue)
-    request_pull_kw(owner, baserepo, issue=int(issue))
+def request_pull_for_issue(owner, repo_base, head, issue):
+    request_pull_kw(owner, repo_base, issue=int(issue))
 
 def list_hooks(owner, repo):
     print_hook_info(snarfer(GET, '/repos/%s/%s/hooks' % (owner, repo)))

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -39,7 +39,8 @@ COMMANDs:
   (*)   unprotect-branch OWNER REPO BRANCH
         list-prs         OWNER REPO
   (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH TITLE BODY
-  (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH {TITLE BODY|ISSUE}
+  (*)   request-pull-for-issue \
+                         OWNER REPO:BRANCH USER:BRANCH ISSUE_NUM
   (*)   merge-pr         OWNER REPO NUMBER
   (*)   close-pr         OWNER REPO NUMBER
   (*)   list-hooks       OWNER REPO
@@ -168,6 +169,9 @@ github API notes:
 : protect-branch PATCH /repos/:owner/:repo/branches/:branch {"enabled": "true"}
 : request-pull   POST /repos/:owner/:repo/pulls {
                       "title": "New Feature", "body": "PR description",
+                      "base": "master", "head": "someuser:somebranch"}
+: request-pull-for-issue
+                 POST /repos/:owner/:repo/pulls {
                       "base": "master", "head": "someuser:somebranch",
                       "issue": 123}
 : merge-pr       PUT /repos/:owner/:repo/pulls/:number/merge
@@ -290,7 +294,7 @@ def close_pr(owner, repo, number):
     snarfer(PATCH, "/repos/%s/%s/pulls/%s" % (owner, repo, number),
            {"state": "closed"})
 
-def request_pull(owner, baserepo, frombranch, title, body=None):
+def request_pull(owner, baserepo, frombranch, title, body):
     repo, base = baserepo.split(':')
 
     head = frombranch
@@ -298,10 +302,19 @@ def request_pull(owner, baserepo, frombranch, title, body=None):
         # probably an error
         pass
 
-    if body is None:
-        data = {"head": head, "base": base, "issue": int(title)}
-    else:
-        data = {"head": head, "base": base, "title": title, "body": body}
+    data = {"head": head, "base": base, "title": title, "body": body}
+
+    print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
+
+def request_pull_for_issue(owner, baserepo, frombranch, issue)
+    repo, base = baserepo.split(':')
+
+    head = frombranch
+    if ':' not in frombranch:
+        # probably an error
+        pass
+
+    data = {"head": head, "base": base, "issue": int(issue)}
 
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
 
@@ -336,6 +349,7 @@ methods = {
     'close-pr':         [close_pr,         True],
     'list-hooks':       [list_hooks,       True],
     'ping-hook':        [ping_hook,        True],
+    'request-pull-for-issue': [request_pull_for_issue, True],
 }
 
 def checkfields(f):

--- a/github/git-hubber
+++ b/github/git-hubber
@@ -39,7 +39,7 @@ COMMANDs:
   (*)   unprotect-branch OWNER REPO BRANCH
         list-prs         OWNER REPO
   (*)   request-pull     OWNER REPO:BRANCH USER:BRANCH TITLE BODY
-  (*)   request-pull-for-issue \
+  (*)   request-pull-for-issue \\
                          OWNER REPO:BRANCH USER:BRANCH ISSUE_NUM
   (*)   merge-pr         OWNER REPO NUMBER
   (*)   close-pr         OWNER REPO NUMBER
@@ -300,10 +300,10 @@ def request_pull_kw(owner, repo_base, head, **kw):
     print_fields([snarfer(POST, '/repos/%s/%s/pulls' % (owner,repo), data)])
 
 def request_pull(owner, repo_base, head, title, body):
-    request_pull_kw(owner, repo_base, title=title, body=body)
+    request_pull_kw(owner, repo_base, head, title=title, body=body)
 
 def request_pull_for_issue(owner, repo_base, head, issue):
-    request_pull_kw(owner, repo_base, issue=int(issue))
+    request_pull_kw(owner, repo_base, head, issue=int(issue))
 
 def list_hooks(owner, repo):
     print_hook_info(snarfer(GET, '/repos/%s/%s/hooks' % (owner, repo)))


### PR DESCRIPTION
Basic user:password auth doesn't work anymore (probably a good thing, i guess).  So make yourself a PAT instead.  Notably, a PAT is already associated with a user, so we get rid of username here as it mostly doesn't do anything.

Secondly, add new `request-pull-for-issue` command for turning an existing non-PR issue into a PR.  (Possibly only doable via the api?)