### PR TITLE
improve el8 detection regex heuristic

### DIFF
--- a/list-rpm-versions
+++ b/list-rpm-versions
@@ -127,7 +127,7 @@ def parse_nevra(item):
     return na,evr
 
 def get_nv_evr_list(items):
-    if re.search(r'[._]el8\b', items[-1]):
+    if re.search(r'[._]el8[._]', items[-1]):
         return map(parse_nevra, items)
     else:
         return group_adjacent(items, 2)


### PR DESCRIPTION
sometimes the %dist for el8 packages contains a '.el8_' rather than
a '.el8.', and if that happens for the final package in the install
list, it will guess the wrong log format.  This little tweak has solved
the issue for me consistently for the last few months at least.

Cheers.