### PR TITLE
Modify Repo Downloader to allow the option to omit git clean

### DIFF
--- a/repodownloader.py
+++ b/repodownloader.py
@@ -174,7 +174,7 @@ def main(argv):
         "--dirty",
         action="store_true",
         type=bool,
-        help="Clean the target directory before fetch and reset",
+        help="Do not clean the target directory before fetch and reset",
     )
     args = parser.parse_args(argv[1:])
 


### PR DESCRIPTION
I need to be able to add files @ /p/condor/public/chtc without them getting overwritten when the cron runs. 

I have made these changes to allow the repo downloader to be configured so that the target directory can be left unclean if wanted. 