### PR TITLE
cleanup email formatting (SOFTWARE-5215)

### DIFF
--- a/github/watchdog
+++ b/github/watchdog
@@ -25,7 +25,7 @@ pretty_mtime() {
 
 cd $repodir
 
-fmtstr='%-35s %-22s %s\n'
+fmtstr='%-49s %-22s %s\n'
 
 # Build the body of the email and collect min/max timestamp
 min_timestamp=$((1 << 32))
@@ -40,7 +40,7 @@ trap "rm -f $message_file" EXIT
     printf "$fmtstr" "--------------" "---------------------" "-------------"
 
     for repo in ./*/*.git; do
-        repo_directory=${repo%./}
+        repo_directory=${repo#./}
 
         if [[ -f $repo/last-success-mtime ]]; then
             last_successful_fetch=`pretty_mtime "$repo/last-success-mtime"`


### PR DESCRIPTION
The paths are longer now and i meant to strip the _leading_ `./` from the path, derp.