### PR TITLE
treat itb and preview/* as wip branches

### DIFF
--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -54,9 +54,13 @@ initrepo () {
     git config transfer.fsckObjects  true
     git config core.logAllRefUpdates true
 
-    # allow non-ff pull request updates, and ff-only updates for all other refs
+    # allow non-ff pull request updates and select wip branches, and
+    # ff-only updates for all other refs
+    wip_branches=("itb" "preview/*" "wip/*")
     git config remote.origin.fetch '+refs/pull/*:refs/pull/*'
-    git config --add remote.origin.fetch '+refs/heads/wip/*:refs/heads/wip/*'
+    for b in "${wip_branches[@]}"; do
+      git config --add remote.origin.fetch "+refs/heads/$b:refs/heads/$b"
+    done
     git config --add remote.origin.fetch 'refs/*:refs/*'
   )
 }


### PR DESCRIPTION
we can eventually put this `wip_branches` list into a separate file if desired, but for the moment i think these three items are ok in the script itself.