### PR TITLE
allow preview-* instead of preview/*, to match existing convention

### DIFF
--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -56,7 +56,7 @@ initrepo () {
 
     # allow non-ff pull request updates and select wip branches, and
     # ff-only updates for all other refs
-    wip_branches=("itb" "preview/*" "wip/*")
+    wip_branches=("itb" "preview-*" "wip/*")
     git config remote.origin.fetch '+refs/pull/*:refs/pull/*'
     for b in "${wip_branches[@]}"; do
       git config --add remote.origin.fetch "+refs/heads/$b:refs/heads/$b"


### PR DESCRIPTION
I guess git allows this after all.