### PR TITLE
Hack: Only allow force pushes to the "itb" branch for topology

### DIFF
--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -59,7 +59,10 @@ initrepo () {
 
     # allow non-ff pull request updates and select wip branches, and
     # ff-only updates for all other refs
-    wip_branches=("itb" "preview-*" "wip/*")
+    wip_branches=("preview-*" "wip/*")
+    if [[ "$(basename "$remote")" == "topology" ]]; then   # sorry :(  -mat
+        wip_branches+=("itb")
+    fi
     git config remote.origin.fetch '+refs/pull/*:refs/pull/*'
     for b in "${wip_branches[@]}"; do
       git config --add remote.origin.fetch "+refs/heads/$b:refs/heads/$b"


### PR DESCRIPTION
Unconditionally adding the
  +refs/heads/itb:refs/heads/itb
line will cause fetches to fail if there's no "itb" branch.

Topology is the repo we added that policy exception for, so test for it explicitly. The real solution is to specify actual config for each repos but that would take significant work...