### PR TITLE
Copy logrotate config to local disk before running logrotate

### DIFF
--- a/github/safe-backup.sh
+++ b/github/safe-backup.sh
@@ -148,5 +148,7 @@ else
     touch $tsdir/last-success-mtime
 fi
 
-/usr/sbin/logrotate --state $logdir/.logrotate.state $srcdir/backups.logrotate
+# copy logrotate config to local disk because logrotate tries to lock it
+cp $srcdir/backups.logrotate $tmpd/backups.logrotate
+/usr/sbin/logrotate --state $logdir/.logrotate.state $tmpd/backups.logrotate
 


### PR DESCRIPTION
This should fix
"error: Could not lock file /p/condor/workspaces/vdt/git/script/backups.logrotate for reading"