### PR TITLE
Add svn-to-monorepo and helper script (SOFTWARE-6076)

### DIFF
--- a/svn-to-monorepo
+++ b/svn-to-monorepo
@@ -124,16 +124,22 @@ GIT svn fetch -q --log-window=1000  ||  fail 7 "Fetch failed"
 # Configure the remote; this also fetches
 #
 GIT remote add -f github https://github.com/${GITHUB_REPOSITORY}  ||  fail 9 "Adding GitHub as a remote failed"
+GIT branch --set-upstream-to=github/main
 
 #
-# Done!
+# Done!  Push if we can do it without rewriting history.
 #
 eecho "*"
 eecho "* Repo conversion complete"
 eecho "*"
-eecho "Run the following to push:"
-eecho "cd \"$DESTDIR\""
-eecho "git push github main"
+
+if GIT merge-base --is-ancestor github/main main
+then
+    eecho "* Fast forward, pushing"
+    GIT push github main  ||  fail 10 "Failed to push"
+else
+    eecho "* New conversion is not a fast forward; please investigate"
+fi
 
 
 # vim:et:sw=4:sts=4:ts=8

--- a/svn-to-monorepo
+++ b/svn-to-monorepo
@@ -83,7 +83,7 @@ set -o nounset
 #
 
 require_program git
-git svn -h >/dev/null || fail 127 "git svn not available"
+git svn -h >/dev/null || fail 127 "git svn not available; try installing the git-svn package (or equivalent on your distribution)"
 require_program curl
 require_program git-filter-repo
 [[ -x $FILTER_SCRIPT ]] || fail 127 "$FILTER_SCRIPT not found or not executable"

--- a/svn-to-monorepo
+++ b/svn-to-monorepo
@@ -135,8 +135,15 @@ eecho "*"
 
 if GIT merge-base --is-ancestor github/main main
 then
-    eecho "* Fast forward, pushing"
-    GIT push github main  ||  fail 10 "Failed to push"
+    eecho "* Resulting repo is a fast-forward"
+    if ask_yn "Push to GitHub?"; then
+        eecho "* Pushing"
+        GIT push github main  ||  fail 10 "Failed to push"
+        eecho "* Done"
+    else
+        eecho "* Not pushing, as requested. Done."
+        exit 0
+    fi
 else
     eecho "* New conversion is not a fast forward; please investigate"
 fi

--- a/svn-to-monorepo
+++ b/svn-to-monorepo
@@ -1,0 +1,139 @@
+#!/bin/bash
+__SUMMARY__=$(cat <<"__TLDR__"
+svn-to-monorepo
+
+Converts the VDT SVN repo to a Git repo with a 'monorepo' layout --
+meaning all of the branches are in a directory, instead of there being
+one Git branch per SVN branch.
+__TLDR__
+)
+
+AUTHORS_FILE=.svn-authors.txt
+AUTHORS_URL=https://vdt.cs.wisc.edu/svn-authors.txt
+GITHUB_REPOSITORY=osg-htc/software-packaging
+SVN=https://vdt.cs.wisc.edu/svn
+
+PROG=${0##*/}
+PROGDIR=$(dirname "$0")
+
+FILTER_SCRIPT=$PROGDIR/svn-to-monorepo-filter-monorepo
+
+ask_yn () {
+    echo >&2 "$@"
+    while read -r; do
+        case $REPLY in
+            [Yy]*) return 0;;
+            [Nn]*) return 1;;
+            *) echo >&2 "Enter yes or no";;
+        esac
+    done
+    return 2  # EOF
+}
+
+eecho () {
+    echo >&2 "$@"
+}
+
+fail () {
+    set +exu
+    ret=${1:-1}
+    shift &>/dev/null || :
+    if [[ -z $* ]]; then
+        echo "$PROG: unspecified failure, exiting" >&2
+    else
+        echo "$PROG:" "$@" >&2
+    fi
+    exit "$ret"
+}
+
+usage () {
+    echo >&2 "$__SUMMARY__"
+    echo >&2
+    echo >&2 "Usage: $PROG <destination>"
+    exit "$1"
+}
+
+require_program () {
+    command -v "$1" &>/dev/null ||
+        fail 127 "Required program '$1' not found in PATH"
+}
+
+GIT () {
+    git -C "$DESTDIR" "$@"
+}
+
+
+#
+# Parse args
+#
+
+if [[ $1 == -h || $1 == --help ]]; then
+    usage 0
+fi
+if [[ $# != 1 ]]; then
+    usage 2
+fi
+DESTDIR=$(readlink -f "$1")
+
+
+set -o nounset
+
+#
+# Check for required programs
+#
+
+require_program git
+git svn -h >/dev/null || fail 127 "git svn not available"
+require_program curl
+require_program git-filter-repo
+[[ -x $FILTER_SCRIPT ]] || fail 127 "$FILTER_SCRIPT not found or not executable"
+
+#
+# Create a fresh dir for the Git repo
+#
+if [[ -d $DESTDIR ]]; then
+    if ask_yn "$DESTDIR already exists. Delete it?"; then
+        rm -rf "$DESTDIR" || fail 4 "Unable to delete $DESTDIR"
+    else
+        fail 4 "Not deleting $DESTDIR"
+    fi
+fi
+mkdir "$DESTDIR" || fail 5 "Could not create $DESTDIR"
+
+#
+# Init the repo
+#
+
+
+GIT svn init $SVN/native/redhat --ignore-paths='^(tags)|(/_[a-z_]+/|[.]tar[.]gz$|[.]rpm$)'  || fail 6 "Error creating Git repo"
+curl -o "$DESTDIR/.git/$AUTHORS_FILE" "$AUTHORS_URL" || fail 7 "Could not download authors file"
+GIT config svn.authorsfile ".git/$AUTHORS_FILE"
+
+#
+# Fetch from SVN and filter the results
+#
+
+eecho "*"
+eecho "* Fetching SVN commits, go make a sandwich"
+eecho "*"
+GIT svn fetch -q --log-window=1000  ||  fail 7 "Fetch failed"
+# Filter needs to be forced because this is not a freshly cloned repo
+"$FILTER_SCRIPT" --force "$DESTDIR"  ||  fail 8 "Filter failed"
+
+#
+# Configure the remote; this also fetches
+#
+GIT remote add -f github https://github.com/${GITHUB_REPOSITORY}  ||  fail 9 "Adding GitHub as a remote failed"
+
+#
+# Done!
+#
+eecho "*"
+eecho "* Repo conversion complete"
+eecho "*"
+eecho "Run the following to push:"
+eecho "cd \"$DESTDIR\""
+eecho "git push github main"
+
+
+# vim:et:sw=4:sts=4:ts=8

--- a/svn-to-monorepo-filter-monorepo
+++ b/svn-to-monorepo-filter-monorepo
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#
+# A helper script for svn-to-monorepo; runs "git filter-repo" to rearrange the monorepo.
+# You will probably not run this by hand, unless you're experimenting.
+#
+
+force=
+if [[ $1 == --force ]]; then
+    force=--force
+    shift
+fi
+
+
+git_dir=${1?Need git dir}
+shift
+if [[ $1 == --force ]]; then  # ugh
+    force=--force
+    shift
+fi
+git -C "${git_dir}" filter-repo --invert-paths \
+    --path-glob '**/*.tar.xz' \
+    --path-glob '**/*.tar.gz' \
+    --path-glob '**/*.tar.bz2' \
+    --path-glob '**/*.src.rpm' \
+    --path-glob '**/_*' \
+    --path-glob 'tags/' \
+    $force
+
+
+args=()
+args+=(--path-rename branches/23-contrib:23-contrib)
+args+=(--path-rename branches/23-empty:23-empty)
+args+=(--path-rename branches/23-internal:23-internal)
+args+=(--path-rename branches/23-main:23-main)
+args+=(--path-rename branches/23-upcoming:23-upcoming)
+args+=(--path-rename branches/24-contrib:24-contrib)
+args+=(--path-rename branches/24-empty:24-empty)
+args+=(--path-rename branches/24-internal:24-internal)
+args+=(--path-rename branches/24-main:24-main)
+args+=(--path-rename branches/24-upcoming:24-upcoming)
+args+=(--path-rename branches/3.6-upcoming:3.6-upcoming)
+args+=(--path-rename branches/devops:devops)
+args+=(--path-rename branches/dist-el7-build:dist-el7-build)
+args+=(--path-rename branches/dist-el8-build:dist-el8-build)
+args+=(--path-rename branches/dist-el9-build:dist-el9-build)
+args+=(--path-rename branches/osg-3.6:osg-3.6)
+args+=(--path-rename branches/osg-3.6-contrib:osg-3.6-contrib)
+args+=(--path-rename branches/osg-internal:osg-internal)
+git -C "${git_dir}" filter-repo "${args[@]}" $force  &&  git -C "${git_dir}" clean -df
+
+
+# vim:et:sw=4:sts=4:ts=8


### PR DESCRIPTION
This converts the VDT SVN repo to a Git repo with a 'monorepo' layout -- meaning all of the branches are in a directory, instead of there being one Git branch per SVN branch.  This will be used for creating and updating the https://github.com/osg-htc/software-packaging repo.

The `git filter-repo` breaks the link to SVN so you will need to rerun the script to do a full re-conversion in order to get new SVN commits (as opposed to just running `git svn rebase` and pushing), but subsequent conversions should still be fast-forward so no force pushing should be necessary.